### PR TITLE
fix(lightline): revert commit fca2ff9ba627bbf172548eb52fcbb03f99ba34e9

### DIFF
--- a/autoload/lightline/colorscheme/gruvbox_material.vim
+++ b/autoload/lightline/colorscheme/gruvbox_material.vim
@@ -19,7 +19,7 @@ if s:configuration.statusline_style ==# 'original' "{{{
   let s:tab_l_fg = s:palette.grey2
   let s:tab_l_bg = s:palette.bg_statusline3
   let s:tab_r_fg = s:palette.bg0
-  let s:tab_r_bg = s:palette.grey1
+  let s:tab_r_bg = s:palette.grey2
   let s:tab_sel_fg = s:palette.bg0
   let s:tab_sel_bg = s:palette.grey2
   let s:tab_middle_fg = s:palette.grey1
@@ -110,7 +110,7 @@ elseif s:configuration.statusline_style ==# 'mix' "{{{
   let s:tab_l_fg = s:palette.grey2
   let s:tab_l_bg = s:palette.bg_statusline3
   let s:tab_r_fg = s:palette.bg0
-  let s:tab_r_bg = s:palette.grey1
+  let s:tab_r_bg = s:palette.grey2
   let s:tab_sel_fg = s:palette.bg0
   let s:tab_sel_bg = s:palette.grey2
   let s:tab_middle_fg = s:palette.grey2
@@ -201,7 +201,7 @@ else "{{{
   let s:tab_l_fg = s:palette.fg1
   let s:tab_l_bg = s:palette.bg_statusline3
   let s:tab_r_fg = s:palette.bg0
-  let s:tab_r_bg = s:palette.grey1
+  let s:tab_r_bg = s:palette.grey2
   let s:tab_sel_fg = s:palette.bg0
   let s:tab_sel_bg = s:palette.grey2
   let s:tab_middle_fg = s:palette.fg1


### PR DESCRIPTION
The tab_r_bg should stay grey2 since it's by design (both gruvbox and gruvbox-material). This color is the background color of the upper right section in this image, which is git information in this case:

https://user-images.githubusercontent.com/37491630/75227134-891fbb80-57a5-11ea-878e-b8b2972cfd6e.png

The problem with #218 and #219 is not here, but with the user's own configuration.